### PR TITLE
feat：添加TPOT（每输出token平均时间）指标支持

### DIFF
--- a/cmd/ait_test.go
+++ b/cmd/ait_test.go
@@ -55,6 +55,9 @@ func NewMockRunner(config types.Input) (*MockRunner, error) {
 				AvgTTFT       time.Duration `json:"avg_ttft"`
 				MinTTFT       time.Duration `json:"min_ttft"`
 				MaxTTFT       time.Duration `json:"max_ttft"`
+				AvgTPOT       time.Duration `json:"avg_tpot"`
+				MinTPOT       time.Duration `json:"min_tpot"`
+				MaxTPOT       time.Duration `json:"max_tpot"`
 				AvgTokenCount int           `json:"avg_token_count"`
 				MinTokenCount int           `json:"min_token_count"`
 				MaxTokenCount int           `json:"max_token_count"`
@@ -65,6 +68,9 @@ func NewMockRunner(config types.Input) (*MockRunner, error) {
 				AvgTTFT:       50 * time.Millisecond,
 				MinTTFT:       30 * time.Millisecond,
 				MaxTTFT:       70 * time.Millisecond,
+				AvgTPOT:       25 * time.Millisecond,
+				MinTPOT:       20 * time.Millisecond,
+				MaxTPOT:       30 * time.Millisecond,
 				AvgTokenCount: 100,
 				MinTokenCount: 80,
 				MaxTokenCount: 120,

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -221,13 +221,14 @@ func (td *Displayer) ShowSignalReport(data *types.ReportData) {
 	table.Append("🔍 DNS 时间", data.NetworkMetrics.MinDNSTime.String(), data.NetworkMetrics.AvgDNSTime.String(), data.NetworkMetrics.MaxDNSTime.String(), "时间", "域名解析耗时 (httptrace)")
 	table.Append("🔒 TLS 时间", data.NetworkMetrics.MinTLSHandshakeTime.String(), data.NetworkMetrics.AvgTLSHandshakeTime.String(), data.NetworkMetrics.MaxTLSHandshakeTime.String(), "时间", "TLS 握手耗时 (httptrace)")
 	table.Append("🔌 TCP 连接时间", data.NetworkMetrics.MinConnectTime.String(), data.NetworkMetrics.AvgConnectTime.String(), data.NetworkMetrics.MaxConnectTime.String(), "时间", "TCP 连接建立耗时 (httptrace)")
+	table.Append("🎲 生成 Token 数", strconv.Itoa(data.ContentMetrics.MinTokenCount), strconv.Itoa(data.ContentMetrics.AvgTokenCount), strconv.Itoa(data.ContentMetrics.MaxTokenCount), "个", "API 返回的 completion tokens")
 
 	// 内容性能指标
 	if data.IsStream {
 		table.Append("⚡ TTFT", data.ContentMetrics.MinTTFT.String(), data.ContentMetrics.AvgTTFT.String(), data.ContentMetrics.MaxTTFT.String(), "时间", "首个 token 响应时间 (含请求发送+网络+服务器处理)")
+		table.Append("⚡ TPOT", data.ContentMetrics.MinTPOT.String(), data.ContentMetrics.AvgTPOT.String(), data.ContentMetrics.MaxTPOT.String(), "时间", "每个输出 token 的平均耗时 (除首token外)")
 	}
 
-	table.Append("🎲 Token 数", strconv.Itoa(data.ContentMetrics.MinTokenCount), strconv.Itoa(data.ContentMetrics.AvgTokenCount), strconv.Itoa(data.ContentMetrics.MaxTokenCount), "个", "API 返回的 completion tokens")
 	table.Append("🚀 TPS", fmt.Sprintf("%.2f", data.ContentMetrics.MinTPS), fmt.Sprintf("%.2f", data.ContentMetrics.AvgTPS), fmt.Sprintf("%.2f", data.ContentMetrics.MaxTPS), "个/秒", "tokens/总耗时 计算得出")
 
 	table.Render()
@@ -244,14 +245,16 @@ func (td *Displayer) ShowMultiReport(data []*types.ReportData) {
 	)
 
 	table.Header("🤖 模型", "🎯 目标 IP", "📊 请求数", "⚡ 并发", "✅ 成功率",
-		"🕐 平均总耗时", "⚡ 平均 TTFT", "🚀 平均 TPS", "🎲 平均 Token 数",
+		"🕐 平均总耗时", "⚡ 平均 TTFT", "⏰ 平均 TPOT", "🚀 平均 TPS", "🎲 平均 Token 数",
 		"🔍 平均 DNS 时间", "🔌 平均 TCP 连接时间", "🔒 平均 TLS 时间")
 
 	for _, report := range data {
-		// TTFT 处理（流式模式才显示）
+		// TTFT 和 TPOT 处理（流式模式才显示）
 		ttftStr := "-"
+		tpotStr := "-"
 		if report.IsStream {
 			ttftStr = report.ContentMetrics.AvgTTFT.String()
+			tpotStr = report.ContentMetrics.AvgTPOT.String()
 		}
 
 		table.Append(
@@ -262,6 +265,7 @@ func (td *Displayer) ShowMultiReport(data []*types.ReportData) {
 			fmt.Sprintf("%.2f%%", report.ReliabilityMetrics.SuccessRate),
 			report.TimeMetrics.AvgTotalTime.String(),
 			ttftStr,
+			tpotStr,
 			fmt.Sprintf("%.2f", report.ContentMetrics.AvgTPS),
 			strconv.Itoa(report.ContentMetrics.AvgTokenCount),
 			report.NetworkMetrics.AvgDNSTime.String(),

--- a/internal/report/csv_renderer.go
+++ b/internal/report/csv_renderer.go
@@ -39,6 +39,7 @@ func (cr *CSVRenderer) Render(data []types.ReportData) (string, error) {
 		"平均TLS握手时间", "最小TLS握手时间", "最大TLS握手时间",
 		// 服务性能指标
 		"平均TTFT", "最小TTFT", "最大TTFT",
+		"平均TPOT", "最小TPOT", "最大TPOT",
 		"平均Token数", "最小Token数", "最大Token数",
 		"平均TPS", "最小TPS", "最大TPS",
 		// 可靠性指标
@@ -49,10 +50,13 @@ func (cr *CSVRenderer) Render(data []types.ReportData) (string, error) {
 	}
 
 	for _, modelData := range data {
-		// 处理TTFT字段，非流式模式显示为"-"
+		// 处理TTFT和TPOT字段，非流式模式显示为"-"
 		avgTTFT := formatDurationForCSV(modelData.ContentMetrics.AvgTTFT, modelData.IsStream)
 		minTTFT := formatDurationForCSV(modelData.ContentMetrics.MinTTFT, modelData.IsStream)
 		maxTTFT := formatDurationForCSV(modelData.ContentMetrics.MaxTTFT, modelData.IsStream)
+		avgTPOT := formatDurationForCSV(modelData.ContentMetrics.AvgTPOT, modelData.IsStream)
+		minTPOT := formatDurationForCSV(modelData.ContentMetrics.MinTPOT, modelData.IsStream)
+		maxTPOT := formatDurationForCSV(modelData.ContentMetrics.MaxTPOT, modelData.IsStream)
 
 		record := []string{
 			// 基础信息
@@ -83,6 +87,9 @@ func (cr *CSVRenderer) Render(data []types.ReportData) (string, error) {
 			avgTTFT,
 			minTTFT,
 			maxTTFT,
+			avgTPOT,
+			minTPOT,
+			maxTPOT,
 			strconv.Itoa(modelData.ContentMetrics.AvgTokenCount),
 			strconv.Itoa(modelData.ContentMetrics.MinTokenCount),
 			strconv.Itoa(modelData.ContentMetrics.MaxTokenCount),

--- a/internal/report/csv_renderer_test.go
+++ b/internal/report/csv_renderer_test.go
@@ -55,7 +55,7 @@ func TestCSVRenderer_Render_EmptyData(t *testing.T) {
 	
 	// 验证头部存在
 	headers := strings.Split(lines[0], ",")
-	expectedHeaderCount := 32 // 基于CSV渲染器中的实际头部数量
+	expectedHeaderCount := 35 // 基于CSV渲染器中的实际头部数量 (原32个 + 3个TPOT字段)
 	if len(headers) != expectedHeaderCount {
 		t.Errorf("Expected %d headers, got %d", expectedHeaderCount, len(headers))
 	}
@@ -122,7 +122,7 @@ func TestCSVRenderer_Render_SingleModel(t *testing.T) {
 	
 	// 验证头部
 	headers := records[0]
-	expectedHeaderCount := 32
+	expectedHeaderCount := 35 // 原32个 + 3个TPOT字段
 	if len(headers) != expectedHeaderCount {
 		t.Errorf("Expected %d headers, got %d", expectedHeaderCount, len(headers))
 	}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -90,6 +90,9 @@ type ReportData struct {
 		AvgTTFT       time.Duration `json:"avg_ttft"`        // 平均首个token响应时间
 		MinTTFT       time.Duration `json:"min_ttft"`        // 最小首个token响应时间
 		MaxTTFT       time.Duration `json:"max_ttft"`        // 最大首个token响应时间
+		AvgTPOT       time.Duration `json:"avg_tpot"`        // 平均每个输出token的耗时（除首token外）
+		MinTPOT       time.Duration `json:"min_tpot"`        // 最小每个输出token的耗时
+		MaxTPOT       time.Duration `json:"max_tpot"`        // 最大每个输出token的耗时
 		AvgTokenCount int           `json:"avg_token_count"` // 平均token数量
 		MinTokenCount int           `json:"min_token_count"` // 最小token数量
 		MaxTokenCount int           `json:"max_token_count"` // 最大token数量
@@ -132,6 +135,9 @@ func (r *ReportData) MarshalJSON() ([]byte, error) {
 			AvgTTFT       string  `json:"avg_ttft"`
 			MinTTFT       string  `json:"min_ttft"`
 			MaxTTFT       string  `json:"max_ttft"`
+			AvgTPOT       string  `json:"avg_tpot"`
+			MinTPOT       string  `json:"min_tpot"`
+			MaxTPOT       string  `json:"max_tpot"`
 			AvgTokenCount int     `json:"avg_token_count"`
 			MinTokenCount int     `json:"min_token_count"`
 			MaxTokenCount int     `json:"max_token_count"`
@@ -178,6 +184,9 @@ func (r *ReportData) MarshalJSON() ([]byte, error) {
 			AvgTTFT       string  `json:"avg_ttft"`
 			MinTTFT       string  `json:"min_ttft"`
 			MaxTTFT       string  `json:"max_ttft"`
+			AvgTPOT       string  `json:"avg_tpot"`
+			MinTPOT       string  `json:"min_tpot"`
+			MaxTPOT       string  `json:"max_tpot"`
 			AvgTokenCount int     `json:"avg_token_count"`
 			MinTokenCount int     `json:"min_token_count"`
 			MaxTokenCount int     `json:"max_token_count"`
@@ -188,6 +197,9 @@ func (r *ReportData) MarshalJSON() ([]byte, error) {
 			AvgTTFT:       formatTTFT(r.ContentMetrics.AvgTTFT, r.IsStream),
 			MinTTFT:       formatTTFT(r.ContentMetrics.MinTTFT, r.IsStream),
 			MaxTTFT:       formatTTFT(r.ContentMetrics.MaxTTFT, r.IsStream),
+			AvgTPOT:       formatTPOT(r.ContentMetrics.AvgTPOT, r.IsStream),
+			MinTPOT:       formatTPOT(r.ContentMetrics.MinTPOT, r.IsStream),
+			MaxTPOT:       formatTPOT(r.ContentMetrics.MaxTPOT, r.IsStream),
 			AvgTokenCount: r.ContentMetrics.AvgTokenCount,
 			MinTokenCount: r.ContentMetrics.MinTokenCount,
 			MaxTokenCount: r.ContentMetrics.MaxTokenCount,
@@ -200,6 +212,14 @@ func (r *ReportData) MarshalJSON() ([]byte, error) {
 
 // formatTTFT 格式化 TTFT 字段，非流式模式返回 "-"
 func formatTTFT(duration time.Duration, isStream bool) string {
+	if !isStream {
+		return "-"
+	}
+	return duration.String()
+}
+
+// formatTPOT 格式化 TPOT 字段，非流式模式返回 "-"
+func formatTPOT(duration time.Duration, isStream bool) string {
 	if !isStream {
 		return "-"
 	}


### PR DESCRIPTION
- 在runner中添加TPOT指标计算逻辑，支持流式和非流式模式
- 在display模块中添加TPOT指标显示，包括单个报告和多个报告对比
- 在CSV报告渲染器中增加TPOT相关字段输出
- 在types中扩展ReportData结构体，添加TPOT相关字段
- 补充相应的单元测试覆盖TPOT功能
- 修复显示模块中Token数字段的显示顺序问题

TPOT计算方式：TPOT = (总耗时 - 首token耗时) / (总token数 - 1)
仅对token数量大于1的请求计算TPOT，提高指标准确性